### PR TITLE
Fix error page for android

### DIFF
--- a/client/components/Error.js
+++ b/client/components/Error.js
@@ -6,16 +6,18 @@ import globalStyles from './globalStyles';
 
 const Error = ({navigation}) => (
   <View style={globalStyles.container}>
-    <Text style={globalStyles.emoji}>😿</Text>
-    <Text style={globalStyles.text}>
-      It looks like something's gone wrong. Please try again. If you're still
-      having a problem please raise an issue on the{' '}
-      <Text
-        style={{color: 'blue'}}
-        onPress={() =>
-          Linking.openURL('https://github.com/komoju/nexus-example/issues/new')
-        }>
-        Github repository
+    <View style={globalStyles.container}>
+      <Text style={globalStyles.emoji}>😿</Text>
+      <Text style={globalStyles.text}>
+        It looks like something's gone wrong. Please try again. If you're still
+        having a problem please raise an issue on the{' '}
+        <Text
+          style={{color: 'blue'}}
+          onPress={() =>
+            Linking.openURL('https://github.com/komoju/nexus-example/issues/new')
+          }>
+          Github repository
+        </Text>
       </Text>
       <Button
         buttonStyle={styles.button}
@@ -23,7 +25,7 @@ const Error = ({navigation}) => (
         titleStyle={{fontSize: 24}}
         onPress={() => navigation.navigate('Welcome')}
       />
-    </Text>
+    </View>
   </View>
 );
 

--- a/client/components/Error.js
+++ b/client/components/Error.js
@@ -6,26 +6,24 @@ import globalStyles from './globalStyles';
 
 const Error = ({navigation}) => (
   <View style={globalStyles.container}>
-    <View style={globalStyles.container}>
-      <Text style={globalStyles.emoji}>😿</Text>
-      <Text style={globalStyles.text}>
-        It looks like something's gone wrong. Please try again. If you're still
-        having a problem please raise an issue on the{' '}
-        <Text
-          style={{color: 'blue'}}
-          onPress={() =>
-            Linking.openURL('https://github.com/komoju/nexus-example/issues/new')
-          }>
-          Github repository
-        </Text>
+    <Text style={globalStyles.emoji}>😿</Text>
+    <Text style={globalStyles.text}>
+      It looks like something's gone wrong. Please try again. If you're still
+      having a problem please raise an issue on the{' '}
+      <Text
+        style={{color: 'blue'}}
+        onPress={() =>
+          Linking.openURL('https://github.com/komoju/nexus-example/issues/new')
+        }>
+        Github repository
       </Text>
-      <Button
-        buttonStyle={styles.button}
-        title="Go Home"
-        titleStyle={{fontSize: 24}}
-        onPress={() => navigation.navigate('Welcome')}
-      />
-    </View>
+    </Text>
+    <Button
+      buttonStyle={styles.button}
+      title="Go Home"
+      titleStyle={{fontSize: 24}}
+      onPress={() => navigation.navigate('Welcome')}
+    />
   </View>
 );
 


### PR DESCRIPTION
I was getting a strange error that said `Cannot add a child that doesn't have a YogaNode to a parent without a measure function!` on my android phone.

Did some troubleshooting, and it turns out React Native for Android doesn't like Button tags inside of Text tags. This PR rearranges the Error component so that the Button is no longer under inside of a Text element.