### PR TITLE
Rename Signatures and Nexus Link, and check Content-Type

### DIFF
--- a/client/App.js
+++ b/client/App.js
@@ -25,7 +25,7 @@ responsible for setting up the routes between components, as well as providing d
 link support. Any URIs that start with komoju-demo:// will be routed to this app.
 When the provider name is clicked on the Komoju website, it is directed to the
 /mobile/landing route of the provider, which redirects to the
-komoju-demo://session/<process-payment-url>. Once the route is opened in the app the
+komoju-demo://nexus_link/<process-payment-url>. Once the route is opened in the app the
 URL is decoded and passed to the PaymentProcessor component, where the process
 payment request is made.
 */
@@ -37,7 +37,7 @@ const App = () => {
     prefixes: ['komoju-demo://'],
     config: {
       PaymentProcessor: {
-        path: 'session/:paymentUrl',
+        path: 'nexus_link/:paymentUrl',
         parse: {
           paymentUrl: encodedUrl => decodeURIComponent(encodedUrl),
         },

--- a/client/components/PaymentProcessor.js
+++ b/client/components/PaymentProcessor.js
@@ -16,7 +16,7 @@ const PaymentProcessor = ({navigation, route}) => {
   const {paymentUrl} = route.params;
   const [hasErrored, setHasErrored] = useState(false);
 
-  const PreFetchOptions = {
+const preFetchOptions = {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/client/components/PaymentProcessor.js
+++ b/client/components/PaymentProcessor.js
@@ -16,6 +16,14 @@ const PaymentProcessor = ({navigation, route}) => {
   const {paymentUrl} = route.params;
   const [hasErrored, setHasErrored] = useState(false);
 
+  const PreFetchOptions = {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+  };
+
   const fetchOptions = {
     method: 'POST',
     headers: {
@@ -26,33 +34,41 @@ const PaymentProcessor = ({navigation, route}) => {
 
   useEffect(() => {
     setHasErrored(false);
-    fetch(paymentUrl, fetchOptions)
-      .then((response) => {
-        if (response.status < 400) {
-          return response.json();
-        } else {
+    fetch(paymentUrl, PreFetchOptions)
+      .then((preResponse) => {
+        if (preResponse.headers.map['content-type'] !== 'application/vnd.nexus-link+json') {
           throw Error(
-            `bad response from Komoju, url: ${paymentUrl}, response code: ${response.status}, response body: ${response.body}`,
+            `Valid endpoints should return "application/vnd.nexus-link+json", url: ${paymentUrl}, response code: ${response.status}, response body: ${response.body}`,
           );
         }
-      })
-      .then((json) => {
-        const {
-          payment: {total, currency, id},
-        } = json;
-        // any information returned from the provider will be inserted into Komoju's
-        // response as a JSON string at
-        // payment.payment_details.authorization_response_text
-        const authorizationResponseText = JSON.parse(
-          json.payment.payment_details.authorization_response_text,
-        );
-
-        navigation.navigate('PaymentConfirmation', {
-          orderId: authorizationResponseText.orderId,
-          paymentId: id,
-          total,
-          currency,
-        });
+        fetch(paymentUrl, fetchOptions)
+          .then((response) => {
+            if (response.status < 400) {
+              return response.json();
+            } else {
+              throw Error(
+                `bad response from Komoju, url: ${paymentUrl}, response code: ${response.status}, response body: ${response.body}`,
+              );
+            }
+          })
+          .then((json) => {
+            const {
+              payment: {total, currency, id},
+            } = json;
+            // any information returned from the provider will be inserted into Komoju's
+            // response as a JSON string at
+            // payment.payment_details.authorization_response_text
+            const authorizationResponseText = JSON.parse(
+              json.payment.payment_details.authorization_response_text,
+            );
+    
+            navigation.navigate('PaymentConfirmation', {
+              orderId: authorizationResponseText.orderId,
+              paymentId: id,
+              total,
+              currency,
+            });
+          })
       })
       .catch((error) => {
         console.log('ERROR: ', error);

--- a/client/components/PaymentProcessor.js
+++ b/client/components/PaymentProcessor.js
@@ -34,7 +34,7 @@ const PaymentProcessor = ({navigation, route}) => {
 
   useEffect(() => {
     setHasErrored(false);
-    fetch(paymentUrl, PreFetchOptions)
+    fetch(paymentUrl, preFetchOptions)
       .then((preResponse) => {
         if (preResponse.headers.map['content-type'] !== 'application/vnd.nexus-link+json') {
           throw Error(

--- a/client/components/PaymentProcessor.js
+++ b/client/components/PaymentProcessor.js
@@ -16,7 +16,7 @@ const PaymentProcessor = ({navigation, route}) => {
   const {paymentUrl} = route.params;
   const [hasErrored, setHasErrored] = useState(false);
 
-const preFetchOptions = {
+  const preFetchOptions = {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',

--- a/provider/app.js
+++ b/provider/app.js
@@ -32,12 +32,12 @@ session query string. This method is responsible for redirecting the mobile devi
 to the client app. In this example we're encoding the session URL and attaching it
 to deep link, so the client app will be able to read the URL and make a request to
 process the payment.
-Example URL: /mobile/landing?session=https://komoju.com/s/p/6l487urgjq4369szt578f07uq
+Example URL: /mobile/landing?nexus_link=https://komoju.com/s/p/6l487urgjq4369szt578f07uq
  */
 app.get("/mobile/landing", (req, res) => {
-  const { session } = req.query;
-  const encodedSessionUrl = encodeURIComponent(session);
-  const appLink = `komoju-demo://session/${encodedSessionUrl}`;
+  const { nexus_link } = req.query;
+  const encodedNexusLink = encodeURIComponent(nexus_link);
+  const appLink = `komoju-demo://session/${encodedNexusLink}`;
 
   console.log("redirecting to deep link:", appLink);
   return res.redirect(appLink);

--- a/provider/app.js
+++ b/provider/app.js
@@ -37,7 +37,7 @@ Example URL: /mobile/landing?nexus_link=https://komoju.com/s/p/6l487urgjq4369szt
 app.get("/mobile/landing", (req, res) => {
   const { nexus_link } = req.query;
   const encodedNexusLink = encodeURIComponent(nexus_link);
-  const appLink = `komoju-demo://session/${encodedNexusLink}`;
+  const appLink = `komoju-demo://nexus_link/${encodedNexusLink}`;
 
   console.log("redirecting to deep link:", appLink);
   return res.redirect(appLink);

--- a/provider/capturePayment.js
+++ b/provider/capturePayment.js
@@ -1,6 +1,6 @@
 const axios = require("axios");
 
-const { generateKomojuProviderSignature } = require("./verifier");
+const { generateNexusProviderSignature } = require("./verifier");
 
 /* 
 This is the endpoint the client directly talks to the provider with to ensure the
@@ -26,7 +26,7 @@ const capturePayment = (req, res) => {
     payment_id: paymentId
   });
 
-  providerSignature = generateKomojuProviderSignature(
+  providerSignature = generateNexusProviderSignature(
     "./keys/private.pem",
     body
   );
@@ -35,7 +35,7 @@ const capturePayment = (req, res) => {
     .post("https://komoju.com/l/callbacks/tim", body, {
       headers: {
         "Content-Type": "application/json",
-        "komoju-provider-signature": providerSignature
+        "nexus-provider-signature": providerSignature
       }
     })
     .then(response => console.log("callback response: ", response.status))

--- a/provider/package.json
+++ b/provider/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "engines": {
-    "node": "12.14.1"
+    "node": ">= 12.14.1"
   },
   "author": "",
   "repository": "https://github.com/komoju/nexus-example",

--- a/provider/reservePayment.js
+++ b/provider/reservePayment.js
@@ -1,6 +1,6 @@
 const { v4: uuidv4 } = require("uuid");
 
-const { verifyKomojuSignature } = require("./verifier");
+const { verifyNexusSignature } = require("./verifier");
 
 /* 
 The reservePayment endpoint is responsible for determining whether the user can make
@@ -15,8 +15,8 @@ Docs: https://docs.komoju.com/en/qr/gateway_integration/#reserve-payment
 Error docs: https://docs.komoju.com/en/qr/gateway_integration/#error-response
 */
 const reservePayment = (req, res) => {
-  const isRequestVerified = verifyKomojuSignature(
-    req.headers["komoju-signature"],
+  const isRequestVerified = verifyNexusSignature(
+    req.headers["nexus-signature"],
     req.body,
     "./keys/komoju-pub.pem"
   );

--- a/provider/verifier.js
+++ b/provider/verifier.js
@@ -2,14 +2,14 @@ const fs = require("fs");
 const crypto = require("crypto");
 
 /*
-Every request that comes from Komoju will have a komoju-signature Header that is a
+Every request that comes from Nexus will have a nexus-signature Header that is a
 HMAC signature, to ensure that the request is truly coming from Komoju. This
 signature is the body of the request encrypted with SHA-256 and then base64 encoded,
 so to verify the signature, you will need to base64 decode it, and decrypt using
 Komoju's public key and compare it against the request body. Since these requests are
 coming from Komoju they all use it's public key, regardless of which provider it is.
 */
-const verifyKomojuSignature = (
+const verifyNexusSignature = (
   signatureHeader,
   requestBody,
   publicKeyFilePath
@@ -26,12 +26,12 @@ const verifyKomojuSignature = (
 
 /*
 All requests made to Komoju need to have the request body signed and added to the
-request as the komoju-signature header. For the request to be successfully accepted
-the komoju-signature will need to match the body of the request, encrypted using the
+request as the nexus-signature header. For the request to be successfully accepted
+the nexus-signature will need to match the body of the request, encrypted using the
 private key that matches the public key supplied to Komoju for the provider and
 base64 encoded.
 */
-const generateKomojuProviderSignature = (privateKeyFilePath, requestBody) => {
+const generateNexusProviderSignature = (privateKeyFilePath, requestBody) => {
   const privateKey = fs.readFileSync(privateKeyFilePath, { encoding: "utf-8" });
   const sign = crypto.createSign("sha256");
   sign.update(requestBody);
@@ -44,6 +44,6 @@ const generateKomojuProviderSignature = (privateKeyFilePath, requestBody) => {
 };
 
 module.exports = {
-  verifyKomojuSignature,
-  generateKomojuProviderSignature
+  verifyNexusSignature,
+  generateNexusProviderSignature
 };


### PR DESCRIPTION
We want to separate provider-facing concepts from merchant-facing concepts. "Session" is a merchant-facing concept, and "Nexus" is a provider-facing one. Hence this PR is raised to avoid confusion between merchants and providers.

Moreover, the verification of the special Content-Type header of 'application/vnd.nexus-link+json' is missing. This PR also added the implementation of it.

For more details, please see the issue referenced below.